### PR TITLE
Add includeNodeModules option to opt into resolving in dependencies

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,14 +4,32 @@ type Resolver = NonNullable<ResolveOptions["resolver"]>;
 
 const pluginName = "ResolveTypescriptPlugin";
 
+export interface ResolveTypescriptPluginOptions {
+    includeNodeModules?: boolean;
+}
+
 export default class ResolveTypescriptPlugin {
+    private static defaultOptions: ResolveTypescriptPluginOptions = {
+        includeNodeModules: false
+    };
+
+    private options: ResolveTypescriptPluginOptions;
+
+    public constructor(options: ResolveTypescriptPluginOptions = {}) {
+        this.options = {...ResolveTypescriptPlugin.defaultOptions, ...options};
+    }
+
     public apply(resolver: Resolver): void {
         const target = resolver.ensureHook("file");
         for (const extension of [".ts", ".tsx"]) {
             resolver
                 .getHook("raw-file")
                 .tapAsync(pluginName, (request, resolveContext, callback) => {
-                    if (!request.path || request.path.match(/(^|[\\/])node_modules($|[\\/])/)) {
+                    if (
+                        !request.path ||
+                        (!this.options.includeNodeModules &&
+                            request.path.match(/(^|[\\/])node_modules($|[\\/])/))
+                    ) {
                         return callback();
                     }
 


### PR DESCRIPTION
As mentioned in [my comment in #5](https://github.com/softwareventures/resolve-typescript-plugin/issues/5#issuecomment-873370006), this adds the ability to opt into transforming imports in `node_modules` (opts out of the existing `node_modules` path check).